### PR TITLE
Add per-slide delay configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,24 @@ The main usage flow is:
    <!--script: Your narration text here -->
    ```
 2. Run `pnpm run voice` to generate audio and then `pnpm slidev --remote` to open the slideshow.
-   The generation script creates files like `public/audio/slide-1.wav`.
+The generation script creates files like `public/audio/slide-1.wav`.
 
 See `TODO.md` for detailed specification.
+
+The `AutoNarrate` component waits 500&nbsp;ms after playback ends before
+advancing to the next slide. You can override this globally by passing a
+`delay` prop in milliseconds:
+
+```vue
+<AutoNarrate :delay="1000" />
+```
+
+You can also specify a per‑slide delay by adding a `delay` value in that
+slide's frontmatter:
+
+```markdown
+---
+delay: 750
+---
+# Slide title
+```

--- a/components/AutoNarrate.vue
+++ b/components/AutoNarrate.vue
@@ -1,6 +1,14 @@
 <script setup lang="ts">
 import { ref, watchEffect, computed } from 'vue'
-import { useNav } from '@slidev/client'
+import { useNav, useSlideContext } from '@slidev/client'
+
+const props = defineProps<{ delay?: number }>()
+const { $frontmatter } = useSlideContext()
+
+const delay = computed(() => {
+  const fmDelay = Number($frontmatter.value?.delay)
+  return Number.isFinite(fmDelay) ? fmDelay : props.delay ?? 500
+})
 
 const nav = useNav()
 const audio = ref<HTMLAudioElement | null>(null)
@@ -9,6 +17,10 @@ const preload = ref<HTMLAudioElement | null>(null)
 const currentSrc = computed(() => `/audio/slide-${nav.currentPage.value}.wav`)
 const nextSrc = computed(() => `/audio/slide-${nav.currentPage.value + 1}.wav`)
 
+const onEnded = () => {
+  setTimeout(() => nav.next(), delay.value)
+}
+
 watchEffect(() => {
   audio.value?.play()
   preload.value?.load()
@@ -16,6 +28,6 @@ watchEffect(() => {
 </script>
 
 <template>
-  <audio :src="currentSrc" autoplay @ended="nav.next()" ref="audio" />
+  <audio :src="currentSrc" autoplay @ended="onEnded" ref="audio" />
   <audio :src="nextSrc" preload="auto" style="display:none" ref="preload" />
 </template>


### PR DESCRIPTION
## Summary
- allow `AutoNarrate` to read a `delay` value from each slide's frontmatter
- document per-slide delay configuration in README

## Testing
- `pnpm install`
- `npx tsc --noEmit`


------
https://chatgpt.com/codex/tasks/task_e_686396e43b2c8325a32e6346bc75f159