### PR TITLE
Add start delay option for AutoNarrate

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,20 +16,22 @@ The generation script creates files like `public/audio/slide-1.wav`.
 
 See `TODO.md` for detailed specification.
 
-The `AutoNarrate` component waits 500&nbsp;ms after playback ends before
-advancing to the next slide. You can override this globally by passing a
-`delay` prop in milliseconds:
+The `AutoNarrate` component waits 500\u00a0ms after playback ends before
+advancing to the next slide. Playback begins as soon as the slide is shown
+unless a start delay is configured. You can override these timings globally by
+passing `delay` and `startDelay` props in milliseconds:
 
 ```vue
-<AutoNarrate :delay="1000" />
+<AutoNarrate :delay="1000" :start-delay="200" />
 ```
 
-You can also specify a per‑slide delay by adding a `delay` value in that
-slide's frontmatter:
+You can also specify per‑slide timings by adding `delay` and `startDelay`
+values in that slide's frontmatter:
 
 ```markdown
 ---
 delay: 750
+startDelay: 200
 ---
 # Slide title
 ```

--- a/components/AutoNarrate.vue
+++ b/components/AutoNarrate.vue
@@ -1,8 +1,8 @@
 <script setup lang="ts">
-import { ref, watchEffect, computed } from 'vue'
+import { ref, watchEffect, computed, onBeforeUnmount } from 'vue'
 import { useNav, useSlideContext } from '@slidev/client'
 
-const props = defineProps<{ delay?: number }>()
+const props = defineProps<{ delay?: number; startDelay?: number }>()
 const { $frontmatter } = useSlideContext()
 
 const delay = computed(() => {
@@ -10,9 +10,15 @@ const delay = computed(() => {
   return Number.isFinite(fmDelay) ? fmDelay : props.delay ?? 500
 })
 
+const startDelay = computed(() => {
+  const fm = Number($frontmatter.value?.startDelay)
+  return Number.isFinite(fm) ? fm : props.startDelay ?? 0
+})
+
 const nav = useNav()
 const audio = ref<HTMLAudioElement | null>(null)
 const preload = ref<HTMLAudioElement | null>(null)
+const timer = ref<number>()
 
 const currentSrc = computed(() => `/audio/slide-${nav.currentPage.value}.wav`)
 const nextSrc = computed(() => `/audio/slide-${nav.currentPage.value + 1}.wav`)
@@ -22,12 +28,23 @@ const onEnded = () => {
 }
 
 watchEffect(() => {
-  audio.value?.play()
+  if (!audio.value) return
+  const el = audio.value
+  el.pause()
+  el.currentTime = 0
+  clearTimeout(timer.value)
+  timer.value = window.setTimeout(() => {
+    el.play()
+  }, startDelay.value)
   preload.value?.load()
+})
+
+onBeforeUnmount(() => {
+  clearTimeout(timer.value)
 })
 </script>
 
 <template>
-  <audio :src="currentSrc" autoplay @ended="onEnded" ref="audio" />
+  <audio :src="currentSrc" @ended="onEnded" ref="audio" />
   <audio :src="nextSrc" preload="auto" style="display:none" ref="preload" />
 </template>


### PR DESCRIPTION
## Summary
- allow configuring a delay before narration starts
- document startDelay usage in README

## Testing
- `pnpm exec tsc --noEmit`


------
https://chatgpt.com/codex/tasks/task_e_6863d1e7c49c832595461c5c3f224fef